### PR TITLE
[SPARK-30871] BUILD Update Protobuf version to avoid known vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <slf4j.version>1.7.16</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <hadoop.version>2.7.4</hadoop.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <protobuf.version>3.4.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.4.14</zookeeper.version>
     <curator.version>2.7.1</curator.version>


### PR DESCRIPTION
Updating Protobuf version as version 2.5.0 is vulnerable to Integer Overflow by allowing remote authenticated attackers to cause a heap-based buffer overflow in serialisation process. This problem has been solved on version 3.4.0. Vulnerability and solution have been published on CVE: https://cve.mitre.org/.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request? 
Update Protobuf version to a newer one in which the vulnerability has been taken care of.


### Why are the changes needed?

An issue was discovered in the protobuf crate before 2.6.0 for Rust. Affected versions of this or prior packages are vulnerable to Integer Overflow by allowing remote authenticated attackers to cause a heap-based buffer overflow in serialisation process.


### Does this PR introduce any user-facing change?
No if user is not an attacker.


### How was this patch tested?
No tests were added, as the only modification was the update of an old dependency to a newer one, and no other code was modified.
